### PR TITLE
Force context check on every raw context call

### DIFF
--- a/nixrs/src/context.rs
+++ b/nixrs/src/context.rs
@@ -5,40 +5,45 @@ use nixrs_sys::{
     NIX_ERR_KEY, NIX_ERR_NIX_ERROR, NIX_ERR_OVERFLOW, NIX_ERR_UNKNOWN, NIX_OK,
 };
 
-use crate::utils::{string_from_c, NixRSError, Result};
+use crate::utils::{string_from_c, Error, Result};
 
 #[derive(Debug)]
-pub struct Context {
-    pub(crate) ctx: *mut nix_c_context,
-}
+pub struct Context(*mut nix_c_context);
 
 impl Context {
-    pub fn new() -> Context {
+    pub fn new() -> Self {
         let ctx = unsafe { nix_c_context_create() };
-        Context { ctx }
+        Self(ctx)
     }
 
-    pub unsafe fn check(&self) -> Result<()> {
-        let err = nix_err_code(self.ctx);
-        if err == NIX_OK as i32 {
+    fn check(&self) -> Result<()> {
+        let error_code = unsafe { nix_err_code(self.0) };
+        if error_code == NIX_OK as i32 {
             return Ok(());
         }
-        let msg = match string_from_c(nix_err_msg(null_mut(), self.ctx, null_mut())) {
-            Ok(msg) => msg,
-            Err(err) => return Err(err),
+        let msg = unsafe { string_from_c(nix_err_msg(null_mut(), self.0, null_mut()))? };
+        let err = match error_code {
+            NIX_ERR_UNKNOWN => Error::NixErrorUnknown(msg),
+            NIX_ERR_OVERFLOW => Error::NixErrorOverflow(msg),
+            NIX_ERR_KEY => Error::NixErrorKey(msg),
+            NIX_ERR_NIX_ERROR => Error::NixErrorNixError(msg),
+            _ => Error::UnknownError,
         };
-        match err {
-            NIX_ERR_UNKNOWN => Err(NixRSError::NixErrorUnknown(msg)),
-            NIX_ERR_OVERFLOW => Err(NixRSError::NixErrorOverflow(msg)),
-            NIX_ERR_KEY => Err(NixRSError::NixErrorKey(msg)),
-            NIX_ERR_NIX_ERROR => Err(NixRSError::NixErrorNixError(msg)),
-            _ => Err(NixRSError::UnknownError),
-        }
+        Err(err)
+    }
+
+    pub(crate) fn exec<F, O>(&self, mut f: F) -> Result<O>
+    where
+        F: FnMut(*mut nix_c_context) -> O,
+    {
+        let output = f(self.0);
+        self.check()?;
+        Ok(output)
     }
 }
 
 impl Drop for Context {
     fn drop(&mut self) {
-        unsafe { nix_c_context_free(self.ctx) };
+        unsafe { nix_c_context_free(self.0) };
     }
 }

--- a/nixrs/src/lib.rs
+++ b/nixrs/src/lib.rs
@@ -1,6 +1,4 @@
-use context::Context;
 use nixrs_sys::{nix_libexpr_init, nix_libstore_init, nix_libutil_init};
-use utils::Result;
 
 pub mod context;
 pub mod path;
@@ -9,15 +7,17 @@ pub mod store;
 pub mod utils;
 pub mod value;
 
+use self::{context::Context, utils::Result};
+
 pub fn init() -> Result<()> {
     let ctx = Context::new();
-    unsafe {
-        nix_libutil_init(ctx.ctx);
-        ctx.check()?;
-        nix_libstore_init(ctx.ctx);
-        ctx.check()?;
-        nix_libexpr_init(ctx.ctx);
-        ctx.check()?;
-    }
-    Ok(())
+    ctx.exec(|ctx| unsafe {
+        nix_libutil_init(ctx);
+    })?;
+    ctx.exec(|ctx| unsafe {
+        nix_libstore_init(ctx);
+    })?;
+    ctx.exec(|ctx| unsafe {
+        nix_libexpr_init(ctx);
+    })
 }

--- a/nixrs/src/path.rs
+++ b/nixrs/src/path.rs
@@ -4,7 +4,7 @@ use std::ffi::CString;
 use crate::{
     context::Context,
     store::Store,
-    utils::{get_string_cb, NixRSError, Result},
+    utils::{get_string_cb, Error, Result},
 };
 
 #[derive(Debug)]
@@ -13,27 +13,23 @@ pub struct StorePath {
 }
 
 impl StorePath {
-    pub(crate) fn new(store: &Store, path: &str) -> Result<StorePath> {
-        let ctx = Context::new();
-        let store_path = unsafe {
-            let path = CString::new(path).map_err(|_| NixRSError::UnknownError)?;
-            let store_path = nix_store_parse_path(ctx.ctx, store.store, path.as_ptr());
-            ctx.check()?;
-            store_path
-        };
-        Ok(StorePath { store_path })
+    pub(crate) fn new(store: &Store, path: &str) -> Result<Self> {
+        let path = CString::new(path).map_err(|_| Error::UnknownError)?;
+        let store_path = Context::new()
+            .exec(|ctx| unsafe { nix_store_parse_path(ctx, store.store, path.as_ptr()) })?;
+        Ok(Self { store_path })
     }
 
     pub fn name(&self) -> Result<String> {
+        let mut vec: Vec<u8> = Vec::new();
         unsafe {
-            let mut vec: Vec<u8> = Vec::new();
             nix_store_path_name(
                 self.store_path,
                 Some(get_string_cb),
                 &mut vec as *mut _ as *mut _,
             );
-            Ok(String::from_utf8(vec).map_err(|_| NixRSError::UnknownError)?)
         }
+        Ok(String::from_utf8(vec).map_err(|_| Error::UnknownError)?)
     }
 }
 

--- a/nixrs/src/state.rs
+++ b/nixrs/src/state.rs
@@ -1,13 +1,14 @@
+use std::{collections::HashMap, ffi::CString, ptr::null};
+
 use nixrs_sys::{
     nix_expr_eval_from_string, nix_state_create, nix_state_free, nix_store_realise, EvalState,
 };
-use std::{collections::HashMap, ffi::CString, ptr::null};
 
 use crate::{
     context::Context,
     path::StorePath,
     store::Store,
-    utils::{build_cb, NixRSError, Result},
+    utils::{build_cb, Error, Result},
     value::{Value, ValueType},
 };
 
@@ -19,25 +20,22 @@ pub struct State {
 }
 
 impl State {
-    pub fn new(store: Store) -> Result<State> {
+    pub fn new(store: Store) -> Result<Self> {
         Self::new_with_paths(store, &[])
     }
 
-    pub fn new_with_paths(store: Store, paths: &[&str]) -> Result<State> {
+    pub fn new_with_paths(store: Store, paths: &[&str]) -> Result<Self> {
         let ctx = Context::new();
         let paths: Vec<_> = paths
             .into_iter()
-            .map(|path| CString::new(path.to_string()).map_err(|_| NixRSError::UnknownError))
+            .map(|path| CString::new(path.to_string()).map_err(|_| Error::UnknownError))
             .collect::<Result<Vec<CString>>>()?;
         let mut paths_c: Vec<_> = paths.iter().map(|path| path.as_ptr()).collect();
         paths_c.push(null());
-        let state = unsafe {
-            let state = nix_state_create(ctx.ctx, paths_c.as_mut_ptr(), store.store);
-            ctx.check()?;
-            state
-        };
+        let state =
+            ctx.exec(|ctx| unsafe { nix_state_create(ctx, paths_c.as_mut_ptr(), store.store) })?;
         drop(paths_c);
-        Ok(State { store, state, ctx })
+        Ok(Self { store, state, ctx })
     }
 
     pub fn eval(&mut self, expr: &str) -> Result<Value> {
@@ -45,20 +43,13 @@ impl State {
     }
 
     pub fn eval_with_path(&mut self, path: &str, expr: &str) -> Result<Value> {
-        unsafe {
-            let expr = CString::new(expr).map_err(|_| NixRSError::UnknownError)?;
-            let path = CString::new(path).map_err(|_| NixRSError::UnknownError)?;
-            let value = Value::new(&self)?;
-            nix_expr_eval_from_string(
-                self.ctx.ctx,
-                self.state,
-                expr.as_ptr(),
-                path.as_ptr(),
-                value.value,
-            );
-            self.ctx.check()?;
-            Ok(value)
-        }
+        let expr = CString::new(expr).map_err(|_| Error::UnknownError)?;
+        let path = CString::new(path).map_err(|_| Error::UnknownError)?;
+        let value = Value::new(&self)?;
+        self.ctx.exec(|ctx| unsafe {
+            nix_expr_eval_from_string(ctx, self.state, expr.as_ptr(), path.as_ptr(), value.value);
+        })?;
+        Ok(value)
     }
 
     pub fn store_path(&mut self, path: &str) -> Result<StorePath> {
@@ -67,25 +58,23 @@ impl State {
 
     pub fn build(&mut self, value: &Value) -> Result<HashMap<String, String>> {
         let ValueType::Attrs = value.get_type()? else {
-            return Err(NixRSError::NotDerivation);
+            return Err(Error::NotDerivation);
         };
         let store_path = value.attrs_get(&self, "drvPath")?;
         let ValueType::String = store_path.get_type()? else {
-            return Err(NixRSError::NotDerivation);
+            return Err(Error::NotDerivation);
         };
         let store_path = StorePath::new(&self.store, store_path.string()?.as_str())?;
-        let map = unsafe {
-            let mut map = HashMap::<String, String>::new();
+        let mut map = HashMap::<String, String>::new();
+        self.ctx.exec(|ctx| unsafe {
             nix_store_realise(
-                self.ctx.ctx,
+                ctx,
                 self.store.store,
                 store_path.store_path,
                 &mut map as *mut _ as *mut _,
                 Some(build_cb),
             );
-            self.ctx.check()?;
-            map
-        };
+        })?;
         Ok(map)
     }
 }

--- a/nixrs/src/utils.rs
+++ b/nixrs/src/utils.rs
@@ -2,10 +2,10 @@ use std::{collections::HashMap, ffi::CStr};
 
 use thiserror::Error;
 
-pub type Result<T> = std::result::Result<T, NixRSError>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Error)]
-pub enum NixRSError {
+pub enum Error {
     #[error("NIX_ERROR_UNKNOWN: {0}")]
     NixErrorUnknown(String),
     #[error("NIX_ERROR_OVERFLOW: {0}")]
@@ -24,7 +24,7 @@ pub(crate) unsafe fn string_from_c(ptr: *const libc::c_char) -> Result<String> {
     CStr::from_ptr(ptr)
         .to_str()
         .map(|str| str.to_string())
-        .map_err(|_| NixRSError::UnknownError)
+        .map_err(|_| Error::UnknownError)
 }
 
 pub(crate) unsafe extern "C" fn get_string_cb(


### PR DESCRIPTION
Instead of manually running the `check` function after every call that uses the raw context e.g. like here:

```rust
nix_libexpr_init(ctx.ctx);
ctx.check()?;
```
We force it by making the `nix_c_context` private, so that you have to use the `exec` function to get access to it:

```rust
ctx.exec(|raw_context| unsafe {
    nix_libexpr_init(raw_context)
})?;
```
This allows us to force the `check()` call:
```rust
 pub(crate) fn exec<F, O>(&self, mut f: F) -> Result<O>
    where
        F: FnMut(*mut nix_c_context) -> O,
    {
        let output = f(self.0);
        self.check()?;
        Ok(output)
    }
```